### PR TITLE
add complex type at init for lenspyx

### DIFF
--- a/delensalot/config/transformer/lerepi2dlensalot.py
+++ b/delensalot/config/transformer/lerepi2dlensalot.py
@@ -409,7 +409,7 @@ class l2delensalotjob_Transformer(l2base_Transformer):
                         dl.stepper_model.mmax_qlm = dl.lm_max_qlm[1]
                         dl.stepper = steps.harmonicbump(dl.stepper_model.lmax_qlm, dl.stepper_model.mmax_qlm, a=dl.stepper_model.a, b=dl.stepper_model.b, xa=dl.stepper_model.xa, xb=dl.stepper_model.xb)
 
-                    dl.ffi = deflection(dl.lenjob_geomlib, np.zeros(shape=hp.Alm.getsize(*dl.lm_max_qlm)), dl.lm_max_qlm[1], numthreads=dl.tr, verbosity=dl.verbose, epsilon=dl.epsilon)
+                    dl.ffi = deflection(dl.lenjob_geomlib, np.zeros(shape=hp.Alm.getsize(*dl.lm_max_qlm), dtype=complex), dl.lm_max_qlm[1], numthreads=dl.tr, verbosity=dl.verbose, epsilon=dl.epsilon)
 
 
                 _process_Meta(dl, cf.meta)
@@ -595,7 +595,7 @@ class l2delensalotjob_Transformer(l2base_Transformer):
                         dl.stepper_model.mmax_qlm = dl.lm_max_qlm[1]
                         dl.stepper = steps.harmonicbump(dl.stepper_model.lmax_qlm, dl.stepper_model.mmax_qlm, a=dl.stepper_model.a, b=dl.stepper_model.b, xa=dl.stepper_model.xa, xb=dl.stepper_model.xb)
                         # dl.stepper = steps.nrstep(dl.lm_max_qlm[0], dl.lm_max_qlm[1], val=0.5) # handler of the size steps in the MAP BFGS iterative search
-                    dl.ffi = deflection(dl.lenjob_geomlib, np.zeros(shape=hp.Alm.getsize(*dl.lm_max_qlm)), dl.lm_max_qlm[1], numthreads=dl.tr, verbosity=dl.verbose, epsilon=dl.epsilon)
+                    dl.ffi = deflection(dl.lenjob_geomlib, np.zeros(shape=hp.Alm.getsize(*dl.lm_max_qlm), dtype=complex), dl.lm_max_qlm[1], numthreads=dl.tr, verbosity=dl.verbose, epsilon=dl.epsilon)
                 
                 _process_Meta(dl, cf.meta)
                 _process_Computing(dl, cf.computing)
@@ -1051,7 +1051,7 @@ class l2delensalotjob_Transformer(l2base_Transformer):
                         dl.stepper_model.mmax_qlm = dl.lm_max_qlm[1]
                         dl.stepper = steps.harmonicbump(dl.stepper_model.lmax_qlm, dl.stepper_model.mmax_qlm, a=dl.stepper_model.a, b=dl.stepper_model.b, xa=dl.stepper_model.xa, xb=dl.stepper_model.xb)
                         # dl.stepper = steps.nrstep(dl.lm_max_qlm[0], dl.lm_max_qlm[1], val=0.5) # handler of the size steps in the MAP BFGS iterative search
-                    dl.ffi = deflection(dl.lenjob_geomlib, np.zeros(shape=hp.Alm.getsize(*dl.lm_max_qlm)), dl.lm_max_qlm[1], numthreads=dl.tr, verbosity=dl.verbose, epsilon=dl.epsilon)
+                    dl.ffi = deflection(dl.lenjob_geomlib, np.zeros(shape=hp.Alm.getsize(*dl.lm_max_qlm), dtype=complex), dl.lm_max_qlm[1], numthreads=dl.tr, verbosity=dl.verbose, epsilon=dl.epsilon)
 
 
                 @log_on_start(logging.DEBUG, "_process_Phianalysis() started")

--- a/delensalot/scripts/run_fromparfile.py
+++ b/delensalot/scripts/run_fromparfile.py
@@ -180,7 +180,7 @@ def get_itlib(k:str, simidx:int, version:str, cg_tol:float, epsilon=1e-5, nbump=
     Rpp_unl, Roo_unl = qresp.get_response(k, lmax_ivf, 'p', cls_unl, cls_unl,
                                           {'e': fel_unl, 'b': fbl_unl, 't': ftl_unl}, lmax_qlm=lmax_qlm)[0:2]
     # Lensing deflection field instance (initiated here with zero deflection)
-    ffi = deflection(lenjob_geometry, np.zeros_like(plm0), mmax_qlm,
+    ffi = deflection(lenjob_geometry, np.zeros_like(plm0, dtype=complex), mmax_qlm,
                      numthreads=numthreads, verbosity=0, epsilon=epsilon)
     if nbump > 0:
         print("Setting up inverse noise drop of Dl = %s"%nbump)


### PR DESCRIPTION
housekeeping
============

[lenspyx'](https://github.com/carronj/lenspyx) latest version requires complex dtype for deflection field initialization at construction