### PR TITLE
bugfix: put maxiter as argument

### DIFF
--- a/delensalot/core/cg/cd_solve.py
+++ b/delensalot/core/cg/cd_solve.py
@@ -111,8 +111,7 @@ class cache_mem(dict):
             del self[key]
 
 
-def cd_solve(x, b, fwd_op, pre_ops, dot_op, criterion, tr, cache=cache_mem(), roundoff=25):
-    maxiter = 10
+def cd_solve(x, b, fwd_op, pre_ops, dot_op, criterion, tr, cache=cache_mem(), roundoff=25, maxiter=10):
     """customizable conjugate directions loop for x=[fwd_op]^{-1}b.
 
     Args:
@@ -190,7 +189,7 @@ def cd_solve(x, b, fwd_op, pre_ops, dot_op, criterion, tr, cache=cache_mem(), ro
             for (searchfwd, alpha) in zip(searchfwds, alphas):
                 residual -= searchfwd * alpha
 
-        plot_stuff(residual, residualdata, bdata, fwddata, xdata, precondata, searchdirs, searchfwds, weights, x)
+        # plot_stuff(residual, residualdata, bdata, fwddata, xdata, precondata, searchdirs, searchfwds, weights, x)
 
         # initial choices for new search directions.
         searchdirs = [pre_op(residual) for pre_op in pre_ops]


### PR DESCRIPTION
behaviour change
==============

a hardcoded `maxiter=10` inside the conjugate gradient accidentally made it into the main branch.

Fixes #98 

@louisl3grand thanks for the catch